### PR TITLE
Change the reset symbol to an invalid input symbol.

### DIFF
--- a/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
@@ -215,7 +215,7 @@ public class DistanceVisitor extends ModifierVisitor<Object> {
         // This is to insert a line main method.
         if (node.getExpression() instanceof VariableDeclarationExpr) {
             if (node.toString().contains("String input = stdin")) {
-                Statement staticStatement = StaticJavaParser.parseStatement("if(input.equals(\"R\")){ eca = new " + class_name + "(); continue; }");
+                Statement staticStatement = StaticJavaParser.parseStatement("if(input.equals(\"#\")){ eca = new " + class_name + "(); continue; }");
                 this.addCodeAfter(node, staticStatement, arg);
                 staticStatement = StaticJavaParser.parseStatement("String input = " + pathFile + ".fuzz(eca.inputs);");
                 node.replace(staticStatement);

--- a/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
@@ -24,7 +24,7 @@ public class DistanceVisitor extends ModifierVisitor<Object> {
 
     /** Name of the source file to instrument */
     private String filename;
-    
+
     private String pathFile = "nl.tudelft.instrumentation.fuzzing.DistanceTracker";
 
     private String class_name = "";

--- a/src/main/java/nl/tudelft/instrumentation/fuzzing/FuzzingLab.java
+++ b/src/main/java/nl/tudelft/instrumentation/fuzzing/FuzzingLab.java
@@ -61,7 +61,7 @@ public class FuzzingLab {
                 for (int i = 0; i < traceLength; i++) {
                         trace.add(symbols[r.nextInt(symbols.length)]);
                 }
-                trace.add("R"); // Reset symbol that marks that we have arrived at the end of a trace.
+                trace.add("#"); // Reset symbol that marks that we have arrived at the end of a trace.
                 return trace;
         }
 

--- a/src/main/java/nl/tudelft/instrumentation/patching/OperatorTracker.java
+++ b/src/main/java/nl/tudelft/instrumentation/patching/OperatorTracker.java
@@ -62,7 +62,7 @@ public class OperatorTracker {
             if(!next_test.isEmpty()) return next_test.pop();
             checkOutput();
             addTest();
-            return "R";
+            return "#";
         }
         return PatchingLab.fuzz(inputSymbols);
     }

--- a/src/main/java/nl/tudelft/instrumentation/patching/OperatorVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/patching/OperatorVisitor.java
@@ -180,7 +180,7 @@ public class OperatorVisitor extends ModifierVisitor<Object> {
         if (node.getExpression() instanceof VariableDeclarationExpr) {
             //System.out.println(node.toString());
             if (node.toString().contains("String input = stdin")) {
-                Statement staticStatement = StaticJavaParser.parseStatement("if(input.equals(\"R\")){ eca = new " + class_name + "(); continue; }");
+                Statement staticStatement = StaticJavaParser.parseStatement("if(input.equals(\"#\")){ eca = new " + class_name + "(); continue; }");
                 this.addCodeAfter(node, staticStatement, arg);
                 staticStatement = StaticJavaParser.parseStatement("String input = " + pathFile + ".fuzz(eca.inputs);");
                 node.replace(staticStatement);

--- a/src/main/java/nl/tudelft/instrumentation/patching/PatchingLab.java
+++ b/src/main/java/nl/tudelft/instrumentation/patching/PatchingLab.java
@@ -69,7 +69,7 @@ public class PatchingLab {
                 }
                 System.out.println();
                 OperatorTracker.startTesting();
-                return "R";
+                return "#";
         }
 
         static void output(String out){

--- a/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
@@ -331,7 +331,7 @@ public class PathVisitor extends ModifierVisitor<Object> {
         if(node.getExpression() instanceof VariableDeclarationExpr){
             //System.out.println(node.toString());
             if(node.toString().contains("String input = stdin")){
-                Statement staticStatement = StaticJavaParser.parseStatement("if(input.equals(\"R\")){ eca = new " + class_name + "(); continue; }");
+                Statement staticStatement = StaticJavaParser.parseStatement("if(input.equals(\"#\")){ eca = new " + class_name + "(); continue; }");
                 this.addCodeAfter(node, staticStatement, arg);
                 staticStatement = StaticJavaParser.parseStatement("MyVar my_input = " + pathFile + ".myInputVar(input, \"input\");");
                 this.addCodeAfter(node, staticStatement, arg);

--- a/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
@@ -46,7 +46,7 @@ public class PathVisitor extends ModifierVisitor<Object> {
      */
     public Node addCode(Statement node, Statement new_statement, Object args){
         if (node.getParentNode().isPresent()){
-        
+
             Node parent = node.getParentNode().get();
 
             if (parent instanceof BlockStmt) {
@@ -78,7 +78,7 @@ public class PathVisitor extends ModifierVisitor<Object> {
      */
     public Node addCodeAfter(Statement node, Statement new_statement, Object args){
         if (node.getParentNode().isPresent()){
-        
+
             Node parent = node.getParentNode().get();
 
             if (parent instanceof BlockStmt) {

--- a/src/main/java/nl/tudelft/instrumentation/symbolic/SymbolicExecutionLab.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/SymbolicExecutionLab.java
@@ -71,7 +71,7 @@ public class SymbolicExecutionLab {
 
     static String fuzz(String[] inputs){
         // do something useful
-        if(r.nextDouble() < 0.01) return "R";
+        if(r.nextDouble() < 0.01) return "#";
         return inputs[r.nextInt(inputs.length)];
     }
 


### PR DESCRIPTION
This PR changes the symbol that resets the system to an unused input symbol. RERS Problems 17, 18 and 19 use `R` as a valid input symbol, so resetting the program whenever an `R` is input makes some states that are reachable in the uninstrumented version of the problem unreachable. I somewhat chose `#` as the new reset symbol because that symbol is not used as input symbol by any of the RERS problems, and it being clearly distinct from normal input symbols, since it is a punctuation mark.