### PR TITLE
Reuse the solver to speedup symbolic execution

### DIFF
--- a/src/main/java/nl/tudelft/instrumentation/symbolic/SymbolicExecutionLab.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/SymbolicExecutionLab.java
@@ -32,7 +32,7 @@ public class SymbolicExecutionLab {
          * obtain a path constraint.
          */
         Expr z3var = c.mkConst(c.mkSymbol(name + "_" + PathTracker.z3counter++), s);
-        PathTracker.z3model = c.mkAnd(c.mkEq(z3var, value), PathTracker.z3model);
+        PathTracker.addToModel(c.mkEq(z3var, value));
         return new MyVar(z3var, name);
     }
 


### PR DESCRIPTION
All constraints except the condition of a branch are the same during symbolic execution. Therefore a single solver can be created once and reused for the whole execution of one trace. 

When solving for a branch, the state of the solver is saved (push), the branch condition is added and the solver is run. After solving, the state of the solver is restored by popping.


Creating and reusing the solver speeds up the process of symbolic execution. This also means less timeouts.
I have experienced speedups of around 10x, but for longer inputs difference will be larger.