### PR TITLE
Fix unary increment operator if only expression on a line

### DIFF
--- a/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
@@ -358,6 +358,12 @@ public class PathVisitor extends ModifierVisitor<Object> {
             }
         }
 
+        // Handle unary expression (eg ++) if it is the only expression on a line.
+        if(node.getExpression() instanceof UnaryExpr) {
+            ExpressionStmt s = new ExpressionStmt(addOwnExpressionCode(node.getExpression().clone(), arg));
+            this.addCode(node, s, arg);
+        }
+
         // Catch the output from the standard out.
         if (node.getExpression() instanceof MethodCallExpr) {
             MethodCallExpr mce = (MethodCallExpr)node.getExpression();

--- a/src/test/java/nl/tudelft/instrumentation/symbolic/PathVisitorTest.java
+++ b/src/test/java/nl/tudelft/instrumentation/symbolic/PathVisitorTest.java
@@ -350,7 +350,6 @@ public class PathVisitorTest {
         assertEquals(1, count);
     }
 
-
     @Test
     public void testConditionalShoudlCreateMyAssignAndConditionalCall(){
         String conditional = "nl.tudelft.instrumentation.symbolic.PathTracker.conditional";

--- a/src/test/java/nl/tudelft/instrumentation/symbolic/PathVisitorTest.java
+++ b/src/test/java/nl/tudelft/instrumentation/symbolic/PathVisitorTest.java
@@ -331,6 +331,27 @@ public class PathVisitorTest {
     }
 
     @Test
+    public void testIncrementShouldCreateIncrementCallForSingleStatement(){
+        String increment= "PathTracker.increment";
+        StringBuilder builder = new StringBuilder();
+        builder.append("public class Test {\n")
+                .append("    public static void main(String[] args) {\n")
+                .append("        a++;\n")
+                .append("    }\n")
+                .append("\n")
+                .append("}");
+
+        String code = builder.toString();
+        CompilationUnit unit = instrument(code);
+        System.out.println(unit.toString());
+
+        int count = StringUtils.countMatches(unit.toString(), increment);
+        assertTrue(unit.toString().contains(increment));
+        assertEquals(1, count);
+    }
+
+
+    @Test
     public void testConditionalShoudlCreateMyAssignAndConditionalCall(){
         String conditional = "nl.tudelft.instrumentation.symbolic.PathTracker.conditional";
         String myAssign = "nl.tudelft.instrumentation.symbolic.PathTracker.myAssign";


### PR DESCRIPTION
# Bug
The increment and decrement operators `++` and `--` were not instrumented if they were the only expressions on a line.
This lead to a discrepancy between the z3 model and the actual values of the running program.

# Fix
The issue has been fixed by also instrumenting unary operators if they are the only expression on a line of code.

# Test
The fix has been verified by adding a test case that verifies the increment operator gets instrumented. Before the change, this test failed.
