### PR TITLE
Only catch the specific exceptions thrown by the problems

### DIFF
--- a/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
@@ -315,7 +315,7 @@ public class PathVisitor extends ModifierVisitor<Object> {
     @Override
     public Node visit(ClassOrInterfaceDeclaration node, Object arg){
         this.class_name = node.getName().toString();
-        BodyDeclaration bd1 = StaticJavaParser.parseBodyDeclaration("public Void call(){ " + class_name + " cp = new " + class_name + "(); for(String s : sequence){ try { MyVar my_s = nl.tudelft.instrumentation.symbolic.PathTracker.myInputVar(s, \"input\"); cp.calculateOutput(s); } catch (Exception e) { nl.tudelft.instrumentation.symbolic.SymbolicExecutionLab.output(\"Invalid input: \" + e.getMessage()); } } return null;}");
+        BodyDeclaration bd1 = StaticJavaParser.parseBodyDeclaration("public Void call(){ " + class_name + " cp = new " + class_name + "(); for(String s : sequence){ try { MyVar my_s = nl.tudelft.instrumentation.symbolic.PathTracker.myInputVar(s, \"input\"); cp.calculateOutput(s); } catch (IllegalArgumentException | IllegalStateException e) { nl.tudelft.instrumentation.symbolic.SymbolicExecutionLab.output(\"Invalid input: \" + e.getMessage()); } } return null;}");
         BodyDeclaration bd2 = StaticJavaParser.parseBodyDeclaration(" public void setSequence(String[] trace){ sequence = trace; } ");
         BodyDeclaration fd = StaticJavaParser.parseBodyDeclaration("public String[] sequence;");
         node.getMembers().add(fd);

--- a/src/test/java/nl/tudelft/instrumentation/symbolic/PathVisitorTest.java
+++ b/src/test/java/nl/tudelft/instrumentation/symbolic/PathVisitorTest.java
@@ -450,7 +450,7 @@ public class PathVisitorTest {
                 "            try {\n" +
                 "                MyVar my_s = nl.tudelft.instrumentation.symbolic.PathTracker.myInputVar(s, \"input\");\n" +
                 "                cp.calculateOutput(s, my_s);\n" +
-                "            } catch (Exception e) {\n" +
+                "            } catch (IllegalArgumentException | IllegalStateException e) {\n" +
                 "                nl.tudelft.instrumentation.symbolic.SymbolicExecutionLab.output(\"Invalid input: \" + e.getMessage());\n" +
                 "            }\n" +
                 "        }\n" +


### PR DESCRIPTION
This allows exceptions that are not an `IllegalArgumentException` or a `StateException` to still crash the program such that a user can see the error, instead of it being consumed.