### PR TITLE
Fix handling of comments in instrumentation

### DIFF
--- a/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
@@ -220,7 +220,7 @@ public class DistanceVisitor extends ModifierVisitor<Object> {
        // Catch the output from the standard out.
         if (node.getExpression() instanceof MethodCallExpr) {
             MethodCallExpr mce = (MethodCallExpr)node.getExpression();
-            if (node.toString().contains("System.out")) {
+            if (mce.toString().contains("System.out")) {
                 node.setExpression(
                         new MethodCallExpr(
                                 new NameExpr(pathFile),"output",mce.getArguments()

--- a/src/main/java/nl/tudelft/instrumentation/patching/OperatorVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/patching/OperatorVisitor.java
@@ -164,7 +164,7 @@ public class OperatorVisitor extends ModifierVisitor<Object> {
 
         if (node.getExpression() instanceof MethodCallExpr) {
             MethodCallExpr mce = (MethodCallExpr)node.getExpression();
-            if (node.toString().contains("System.out")) {
+            if (mce.toString().contains("System.out")) {
                 node.setExpression(
                         new MethodCallExpr(
                                 new NameExpr(pathFile),"output",mce.getArguments()

--- a/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
@@ -367,7 +367,7 @@ public class PathVisitor extends ModifierVisitor<Object> {
         // Catch the output from the standard out.
         if (node.getExpression() instanceof MethodCallExpr) {
             MethodCallExpr mce = (MethodCallExpr)node.getExpression();
-            if (node.toString().contains("System.out")) {
+            if (mce.toString().contains("System.out")) {
                 node.setExpression(
                         new MethodCallExpr(
                                 new NameExpr(pathFile),"output",mce.getArguments()


### PR DESCRIPTION
The instrumentation wrongly instrumented code that contained comments. A `Node.toString()` could include any previous comments. If the comments then contained `System.out`, the code after the comment would get instrumented. By checking the `MethodCallExpr` this has been fixed, as that does not include comments.