### PR TITLE
Add summary script for KLEE

### DIFF
--- a/docs/symbolic_rers.md
+++ b/docs/symbolic_rers.md
@@ -297,6 +297,26 @@ and send it to the SMT solver, although I am not yet sure on how to get the outp
 (again, all binaries of KLEE are located in `/home/str/klee/build/bin/`)
 
 
+We created a Python script that computes the summary of the errors that were found by KLEE. The script is located in `scripts/analyze_klee_live.py`. The script requires the output of KLEE to be its input. To run KLEE while collecting the summary, run the command listed below. This pipes the output of KLEE on stderr to the `analyze_klee_live.py`.
+
+```
+./path/to/klee/binary/klee /path/to/instrumented/Problem10.bc 2>&1 | python3 ./path/to/analyze_klee_live.py
+```
+
+Running this command gives the following summary:
+```
+...
+
+Summary:
+error_8 found in 13.299s
+error_77 found in 11.550s
+error_79 found in 13.261s
+Found 3 unique errors
+
+...
+```
+
+
 Read more on the features of KLEE at: http://klee.github.io/docs/. Happy bug hunting.
 
 https://feliam.wordpress.com/2010/10/07/the-symbolic-maze/ is also well-worth checking out.

--- a/scripts/analyze_klee_live.py
+++ b/scripts/analyze_klee_live.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import sys
+import re
+import time
+error_regex = re.compile(r'error_([0-9]+)')
+
+start_time = time.time()
+error_dict = {}
+
+verbose = True
+
+try:
+    for line in sys.stdin:
+        if verbose:
+            print(line, end='')
+        for error in error_regex.findall(line):
+            error = int(error)
+            if error not in error_dict:
+                dt = time.time() - start_time
+                error_dict[error]= dt
+                print(f'[info] Found new error: error_{error} in {dt}')
+except KeyboardInterrupt:
+    sys.stdout.flush()
+    pass
+
+print('\nSummary:')
+for error, t in sorted(error_dict.items()):
+    print(f'error_{error} found in {t:.3f}s')
+print(f'Found {len(error_dict)} unique errors')


### PR DESCRIPTION
Add a script that computes the summary of the errors found by KLEE.
The script requires stderr of KLEE to be piped in as input. This has been documented in the `symbolic_rers.md` file.