### PR TITLE
Make instrumentation more compact

### DIFF
--- a/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
@@ -242,7 +242,7 @@ public class DistanceVisitor extends ModifierVisitor<Object> {
     @Override
     public Node visit(ClassOrInterfaceDeclaration node, Object arg){
         this.class_name = node.getName().toString();
-        BodyDeclaration bd1 = StaticJavaParser.parseBodyDeclaration("public Void call(){ " + class_name + " cp = new " + class_name + "(); for(String s : sequence){ try { cp.calculateOutput(s); } catch (Exception e) { nl.tudelft.instrumentation.fuzzing.FuzzingLab.output(\"Invalid input: \" + e.getMessage()); } } return null;}");
+        BodyDeclaration bd1 = StaticJavaParser.parseBodyDeclaration("public Void call(){ " + class_name + " cp = new " + class_name + "(); for(String s : sequence){ try { cp.calculateOutput(s); } catch (Exception e) { FuzzingLab.output(\"Invalid input: \" + e.getMessage()); } } return null;}");
         BodyDeclaration bd2 = StaticJavaParser.parseBodyDeclaration(" public void setSequence(String[] trace){ sequence = trace; } ");
         BodyDeclaration fd = StaticJavaParser.parseBodyDeclaration("public String[] sequence;");
         node.getMembers().add(fd);

--- a/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitor.java
@@ -24,7 +24,7 @@ public class DistanceVisitor extends ModifierVisitor<Object> {
     /** Name of the source file to instrument */
     private String filename;
 
-    private String pathFile = "nl.tudelft.instrumentation.fuzzing.DistanceTracker";
+    private String pathFile = "DistanceTracker";
 
     private String class_name = "";
 

--- a/src/main/java/nl/tudelft/instrumentation/patching/OperatorVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/patching/OperatorVisitor.java
@@ -135,7 +135,7 @@ public class OperatorVisitor extends ModifierVisitor<Object> {
     @Override
     public Node visit(ClassOrInterfaceDeclaration node, Object arg){
         this.class_name = node.getName().toString();
-        BodyDeclaration bd1 = StaticJavaParser.parseBodyDeclaration("public Void call(){ " + class_name + " cp = new " + class_name + "(); for(String s : sequence){ try { cp.calculateOutput(s); } catch (Exception e) { nl.tudelft.instrumentation.patching.PatchingLab.output(\"Invalid input: \" + e.getMessage()); } } return null;}");
+        BodyDeclaration bd1 = StaticJavaParser.parseBodyDeclaration("public Void call(){ " + class_name + " cp = new " + class_name + "(); for(String s : sequence){ try { cp.calculateOutput(s); } catch (Exception e) { PatchingLab.output(\"Invalid input: \" + e.getMessage()); } } return null;}");
         BodyDeclaration bd2 = StaticJavaParser.parseBodyDeclaration(" public void setSequence(String[] trace){ sequence = trace; } ");
         BodyDeclaration fd = StaticJavaParser.parseBodyDeclaration("public String[] sequence;");
         node.getMembers().add(fd);

--- a/src/main/java/nl/tudelft/instrumentation/patching/OperatorVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/patching/OperatorVisitor.java
@@ -23,7 +23,7 @@ public class OperatorVisitor extends ModifierVisitor<Object> {
     /** Name of the source file to instrument */
     private String filename;
 
-    private String pathFile = "nl.tudelft.instrumentation.patching.OperatorTracker";
+    private String pathFile = "OperatorTracker";
 
     private String class_name = "";
 

--- a/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/PathVisitor.java
@@ -25,7 +25,7 @@ public class PathVisitor extends ModifierVisitor<Object> {
 
     /** Name of the source file to instrument */
     private String filename;
-    private String pathFile = "nl.tudelft.instrumentation.symbolic.PathTracker";
+    private String pathFile = "PathTracker";
 
     private String class_name = "";
 
@@ -315,7 +315,7 @@ public class PathVisitor extends ModifierVisitor<Object> {
     @Override
     public Node visit(ClassOrInterfaceDeclaration node, Object arg){
         this.class_name = node.getName().toString();
-        BodyDeclaration bd1 = StaticJavaParser.parseBodyDeclaration("public Void call(){ " + class_name + " cp = new " + class_name + "(); for(String s : sequence){ try { MyVar my_s = nl.tudelft.instrumentation.symbolic.PathTracker.myInputVar(s, \"input\"); cp.calculateOutput(s); } catch (IllegalArgumentException | IllegalStateException e) { nl.tudelft.instrumentation.symbolic.SymbolicExecutionLab.output(\"Invalid input: \" + e.getMessage()); } } return null;}");
+        BodyDeclaration bd1 = StaticJavaParser.parseBodyDeclaration("public Void call(){ " + class_name + " cp = new " + class_name + "(); for(String s : sequence){ try { MyVar my_s = PathTracker.myInputVar(s, \"input\"); cp.calculateOutput(s); } catch (IllegalArgumentException | IllegalStateException e) { SymbolicExecutionLab.output(\"Invalid input: \" + e.getMessage()); } } return null;}");
         BodyDeclaration bd2 = StaticJavaParser.parseBodyDeclaration(" public void setSequence(String[] trace){ sequence = trace; } ");
         BodyDeclaration fd = StaticJavaParser.parseBodyDeclaration("public String[] sequence;");
         node.getMembers().add(fd);

--- a/src/test/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitorTest.java
+++ b/src/test/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitorTest.java
@@ -29,7 +29,7 @@ public class DistanceVisitorTest {
 
     @Test
     public void testSimpleIfShouldCreateOneBinaryExpression(){
-        String binExpr = "nl.tudelft.instrumentation.fuzzing.DistanceTracker.binaryExpr";
+        String binExpr = "DistanceTracker.binaryExpr";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -50,7 +50,7 @@ public class DistanceVisitorTest {
 
     @Test
     public void testSimpleIfShouldCreateOneMyIfMethodCall(){
-        String myIfCall = "nl.tudelft.instrumentation.fuzzing.DistanceTracker.myIf";
+        String myIfCall = "DistanceTracker.myIf";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -71,7 +71,7 @@ public class DistanceVisitorTest {
 
     @Test
     public void testSimpleIfShouldCreateTwoMyVars(){
-        String myVar = "nl.tudelft.instrumentation.fuzzing.DistanceTracker.MyVar";
+        String myVar = "DistanceTracker.MyVar";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -92,7 +92,7 @@ public class DistanceVisitorTest {
 
     @Test
     public void testNestedIfShouldCreateTwoMyIfCalls(){
-        String myIf = "nl.tudelft.instrumentation.fuzzing.DistanceTracker.myIf";
+        String myIf = "DistanceTracker.myIf";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -115,7 +115,7 @@ public class DistanceVisitorTest {
 
     @Test
     public void testSimpleIfShouldCreateOneUnaryExpression(){
-        String unExpr = "nl.tudelft.instrumentation.fuzzing.DistanceTracker.unaryExpr";
+        String unExpr = "DistanceTracker.unaryExpr";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -136,7 +136,7 @@ public class DistanceVisitorTest {
 
     @Test
     public void testEqualsShouldConvertToMyVarEquals(){
-        String myVarEquals = "nl.tudelft.instrumentation.fuzzing.DistanceTracker.equals";
+        String myVarEquals = "DistanceTracker.equals";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -178,7 +178,7 @@ public class DistanceVisitorTest {
 
     @Test
     public void testManyComparisonsInIfCreatesManyBinaryExpressions(){
-        String binExpr = "nl.tudelft.instrumentation.fuzzing.DistanceTracker.binaryExpr";
+        String binExpr = "DistanceTracker.binaryExpr";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -319,7 +319,7 @@ public class DistanceVisitorTest {
 
     @Test
     public void testInstrumentationShouldCreateRunCall(){
-        String runCall = "nl.tudelft.instrumentation.fuzzing.DistanceTracker.run(eca.inputs, eca);";
+        String runCall = "DistanceTracker.run(eca.inputs, eca);";
 
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")

--- a/src/test/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitorTest.java
+++ b/src/test/java/nl/tudelft/instrumentation/fuzzing/DistanceVisitorTest.java
@@ -247,7 +247,7 @@ public class DistanceVisitorTest {
                 "            try {\n" +
                 "                cp.calculateOutput(s);\n" +
                 "            } catch (Exception e) {\n" +
-                "                nl.tudelft.instrumentation.fuzzing.FuzzingLab.output(\"Invalid input: \" + e.getMessage());\n" +
+                "                FuzzingLab.output(\"Invalid input: \" + e.getMessage());\n" +
                 "            }\n" +
                 "        }\n" +
                 "        return null;\n" +

--- a/src/test/java/nl/tudelft/instrumentation/patching/OperatorVisitorTest.java
+++ b/src/test/java/nl/tudelft/instrumentation/patching/OperatorVisitorTest.java
@@ -137,7 +137,7 @@ public class OperatorVisitorTest {
 
     @Test
     public void testEqualsOperatorShouldCreateMyOperatorCall(){
-        String myOperator = "nl.tudelft.instrumentation.patching.OperatorTracker.myOperator(\"==\", a, b, 0)";
+        String myOperator = "OperatorTracker.myOperator(\"==\", a, b, 0)";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -158,7 +158,7 @@ public class OperatorVisitorTest {
 
     @Test
     public void testNotEqualsOperatorShouldCreateMyOperatorCall(){
-        String myOperator = "nl.tudelft.instrumentation.patching.OperatorTracker.myOperator(\"!=\", a, b, 0)";
+        String myOperator = "OperatorTracker.myOperator(\"!=\", a, b, 0)";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -179,7 +179,7 @@ public class OperatorVisitorTest {
 
     @Test
     public void testGTOperatorShouldCreateMyOperatorCall(){
-        String myOperator = "nl.tudelft.instrumentation.patching.OperatorTracker.myOperator(\">\", a, b, 0)";
+        String myOperator = "OperatorTracker.myOperator(\">\", a, b, 0)";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -200,7 +200,7 @@ public class OperatorVisitorTest {
 
     @Test
     public void testGEOperatorShouldCreateMyOperatorCall(){
-        String myOperator = "nl.tudelft.instrumentation.patching.OperatorTracker.myOperator(\">=\", a, b, 0)";
+        String myOperator = "OperatorTracker.myOperator(\">=\", a, b, 0)";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -221,7 +221,7 @@ public class OperatorVisitorTest {
 
     @Test
     public void testLTOperatorShouldCreateMyOperatorCall(){
-        String myOperator = "nl.tudelft.instrumentation.patching.OperatorTracker.myOperator(\"<\", a, b, 0)";
+        String myOperator = "OperatorTracker.myOperator(\"<\", a, b, 0)";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -242,7 +242,7 @@ public class OperatorVisitorTest {
 
     @Test
     public void testLEOperatorShouldCreateMyOperatorCall(){
-        String myOperator = "nl.tudelft.instrumentation.patching.OperatorTracker.myOperator(\"<=\", a, b, 0)";
+        String myOperator = "OperatorTracker.myOperator(\"<=\", a, b, 0)";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -383,7 +383,7 @@ public class OperatorVisitorTest {
 
     @Test
     public void testInstrumentationShouldCreateRunCall(){
-        String runCall = "nl.tudelft.instrumentation.patching.OperatorTracker.run(operators, eca);";
+        String runCall = "OperatorTracker.run(operators, eca);";
 
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")

--- a/src/test/java/nl/tudelft/instrumentation/patching/OperatorVisitorTest.java
+++ b/src/test/java/nl/tudelft/instrumentation/patching/OperatorVisitorTest.java
@@ -311,7 +311,7 @@ public class OperatorVisitorTest {
                 "            try {\n" +
                 "                cp.calculateOutput(s);\n" +
                 "            } catch (Exception e) {\n" +
-                "                nl.tudelft.instrumentation.patching.PatchingLab.output(\"Invalid input: \" + e.getMessage());\n" +
+                "                PatchingLab.output(\"Invalid input: \" + e.getMessage());\n" +
                 "            }\n" +
                 "        }\n" +
                 "        return null;\n" +

--- a/src/test/java/nl/tudelft/instrumentation/symbolic/PathVisitorTest.java
+++ b/src/test/java/nl/tudelft/instrumentation/symbolic/PathVisitorTest.java
@@ -29,7 +29,7 @@ public class PathVisitorTest {
 
     @Test
     public void testSimpleIntGlobalShouldCreateMyVar(){
-        String createMyVar = "MyVar my_a = nl.tudelft.instrumentation.symbolic.PathTracker.myVar(55, \"my_a\");";
+        String createMyVar = "MyVar my_a = PathTracker.myVar(55, \"my_a\");";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    int a = 55;\n")
@@ -51,7 +51,7 @@ public class PathVisitorTest {
 
     @Test
     public void testSimpleBoolGlobalShouldCreateMyVar(){
-        String createMyVar = "MyVar my_bool = nl.tudelft.instrumentation.symbolic.PathTracker.myVar(true, \"my_bool\");";
+        String createMyVar = "MyVar my_bool = PathTracker.myVar(true, \"my_bool\");";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    boolean bool = true;\n")
@@ -73,7 +73,7 @@ public class PathVisitorTest {
 
     @Test
     public void testSimpleArrayGlobalShouldCreateMyVar(){
-        String createMyVar = "MyVar[] my_arr = { nl.tudelft.instrumentation.symbolic.PathTracker.myVar(1, \"my_arr0\"), nl.tudelft.instrumentation.symbolic.PathTracker.myVar(2, \"my_arr1\"), nl.tudelft.instrumentation.symbolic.PathTracker.myVar(3, \"my_arr2\") };";
+        String createMyVar = "MyVar[] my_arr = { PathTracker.myVar(1, \"my_arr0\"), PathTracker.myVar(2, \"my_arr1\"), PathTracker.myVar(3, \"my_arr2\") };";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    int[] arr = {1, 2 ,3};\n")
@@ -95,7 +95,7 @@ public class PathVisitorTest {
 
     @Test
     public void testSimpleStringGlobalShouldCreateMyVar(){
-        String createMyVar = "MyVar my_s = nl.tudelft.instrumentation.symbolic.PathTracker.myVar(\"test\", \"my_s\");";
+        String createMyVar = "MyVar my_s = PathTracker.myVar(\"test\", \"my_s\");";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    String s = \"test\";\n")
@@ -117,7 +117,7 @@ public class PathVisitorTest {
 
     @Test
     public void testArrayAssignmentToVarGlobalShouldCreateMyVar(){
-        String createMyVar = "MyVar[] my_arrB = nl.tudelft.instrumentation.symbolic.PathTracker.myVar(my_arrA, \"my_arrB\");";
+        String createMyVar = "MyVar[] my_arrB = PathTracker.myVar(my_arrA, \"my_arrB\");";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    int[] arrA = {1, 2 ,3};\n")
@@ -140,7 +140,7 @@ public class PathVisitorTest {
 
     @Test
     public void testSimpleIfShouldCreateOneBinaryExpression(){
-        String binExpr = "nl.tudelft.instrumentation.symbolic.PathTracker.binaryExpr";
+        String binExpr = "PathTracker.binaryExpr";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -161,7 +161,7 @@ public class PathVisitorTest {
 
     @Test
     public void testSimpleIfShouldCreateOneMyIfMethodCall(){
-        String myIfCall = "nl.tudelft.instrumentation.symbolic.PathTracker.myIf";
+        String myIfCall = "PathTracker.myIf";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -182,7 +182,7 @@ public class PathVisitorTest {
 
     @Test
     public void testSimpleIfShouldCreateTempVar(){
-        String myVar = "nl.tudelft.instrumentation.symbolic.PathTracker.tempVar";
+        String myVar = "PathTracker.tempVar";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -203,7 +203,7 @@ public class PathVisitorTest {
 
     @Test
     public void testNestedIfShouldCreateTwoMyIfCalls(){
-        String myIf = "nl.tudelft.instrumentation.symbolic.PathTracker.myIf";
+        String myIf = "PathTracker.myIf";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -226,7 +226,7 @@ public class PathVisitorTest {
 
     @Test
     public void testSimpleIfShouldCreateOneUnaryExpression(){
-        String unExpr = "nl.tudelft.instrumentation.symbolic.PathTracker.unaryExpr";
+        String unExpr = "PathTracker.unaryExpr";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -247,7 +247,7 @@ public class PathVisitorTest {
 
     @Test
     public void testEqualsShouldConvertToMyVarEquals(){
-        String myVarEquals = "nl.tudelft.instrumentation.symbolic.PathTracker.equals";
+        String myVarEquals = "PathTracker.equals";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -268,7 +268,7 @@ public class PathVisitorTest {
 
     @Test
     public void testInstrumentationShouldAddImport(){
-        String imprt = "import nl.tudelft.instrumentation.symbolic.*;";
+        String imprt = "import nl.tudelft.instrumentation.symbolic.*";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -289,7 +289,7 @@ public class PathVisitorTest {
 
     @Test
     public void testManyComparisonsInIfCreatesManyBinaryExpressions(){
-        String binExpr = "nl.tudelft.instrumentation.symbolic.PathTracker.binaryExpr";
+        String binExpr = "PathTracker.binaryExpr";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -310,7 +310,7 @@ public class PathVisitorTest {
 
     @Test
     public void testIncrementShouldCreateIncrementCall(){
-        String increment= "nl.tudelft.instrumentation.symbolic.PathTracker.increment";
+        String increment= "PathTracker.increment";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -352,8 +352,8 @@ public class PathVisitorTest {
 
     @Test
     public void testConditionalShoudlCreateMyAssignAndConditionalCall(){
-        String conditional = "nl.tudelft.instrumentation.symbolic.PathTracker.conditional";
-        String myAssign = "nl.tudelft.instrumentation.symbolic.PathTracker.myAssign";
+        String conditional = "PathTracker.conditional";
+        String myAssign = "PathTracker.myAssign";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -378,7 +378,7 @@ public class PathVisitorTest {
 
     @Test
     public void testArrayAccessShouldCreateArrayIndCall(){
-        String arrayInd = "nl.tudelft.instrumentation.symbolic.PathTracker.arrayInd";
+        String arrayInd = "PathTracker.arrayInd";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -400,7 +400,7 @@ public class PathVisitorTest {
 
     @Test
     public void testDecrementShouldCreateIncrementCall(){
-        String decrement = "nl.tudelft.instrumentation.symbolic.PathTracker.increment";
+        String decrement = "PathTracker.increment";
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")
                 .append("    public static void main(String[] args) {\n")
@@ -468,10 +468,10 @@ public class PathVisitorTest {
                 "        Test cp = new Test();\n" +
                 "        for (String s : sequence) {\n" +
                 "            try {\n" +
-                "                MyVar my_s = nl.tudelft.instrumentation.symbolic.PathTracker.myInputVar(s, \"input\");\n" +
+                "                MyVar my_s = PathTracker.myInputVar(s, \"input\");\n" +
                 "                cp.calculateOutput(s, my_s);\n" +
                 "            } catch (IllegalArgumentException | IllegalStateException e) {\n" +
-                "                nl.tudelft.instrumentation.symbolic.SymbolicExecutionLab.output(\"Invalid input: \" + e.getMessage());\n" +
+                "                SymbolicExecutionLab.output(\"Invalid input: \" + e.getMessage());\n" +
                 "            }\n" +
                 "        }\n" +
                 "        return null;\n" +
@@ -543,7 +543,7 @@ public class PathVisitorTest {
 
     @Test
     public void testInstrumentationShouldCreateRunCall(){
-        String runCall = "nl.tudelft.instrumentation.symbolic.PathTracker.run(eca.inputs, eca);";
+        String runCall = "PathTracker.run(eca.inputs, eca);";
 
         StringBuilder builder = new StringBuilder();
         builder.append("public class Test {\n")


### PR DESCRIPTION
The instrumentation included the full path of all the classes.
These full paths were unnecessary as the classes were already imported with a start (`.*`) import.