### PR TITLE
Set timeout on solver, instead of the whole trace

### DIFF
--- a/src/main/java/nl/tudelft/instrumentation/symbolic/PathTracker.java
+++ b/src/main/java/nl/tudelft/instrumentation/symbolic/PathTracker.java
@@ -35,7 +35,10 @@ public class PathTracker {
         z3model    = ctx.mkTrue();
         z3branches = ctx.mkTrue();
         inputs.clear();
-        solver = ctx.mkSolver();
+        solver.reset();
+        Params params = ctx.mkParams();
+        params.add("timeout", timeoutMS);
+        solver.setParameters(params);
     }
 
 
@@ -261,10 +264,9 @@ public class PathTracker {
     public static void runNextFuzzedSequence(String[] sequence) {
         problem.setSequence(sequence);
         final Future handler = executor.submit(problem);
-        executor.schedule(() -> {
-            handler.cancel(true);
-        }, timeoutMS, TimeUnit.MILLISECONDS);
-
+        // executor.schedule(() -> {
+        //     handler.cancel(true);
+        // }, timeoutMS, TimeUnit.MILLISECONDS);
         // Wait for it to be completed
         try {
             handler.get();


### PR DESCRIPTION
The timeouts can be an issue for the symbolic executor.

The timeouts were for a full trace, and the interruption wouldn't allow continuing after a timeout.
Now the timeouts are per solve and do allow continuing, while still capping the time of the solver.